### PR TITLE
docs: correct typo in minikube+https documentation

### DIFF
--- a/getting-started/deployment/minikube-+-https.md
+++ b/getting-started/deployment/minikube-+-https.md
@@ -119,7 +119,7 @@ minikube addons enable ingress
 
 ### Helm Values.
 
-We need to generate a file called **value.yaml** with the following using the content of our rootCa.pem from the previous step:
+We need to generate a file called **values.yaml** with the following using the content of our rootCa.pem from the previous step:
 
 ```
 security:


### PR DESCRIPTION
- Use values.yml instead of value.yml as filename to make it work with the subsequent command